### PR TITLE
remove memoization from recharts definitions

### DIFF
--- a/src/components/ForecastTable.tsx
+++ b/src/components/ForecastTable.tsx
@@ -1,5 +1,4 @@
 import { ForecastResponse } from '../weatherData/weatherApi';
-import { memo, useCallback } from 'react';
 
 interface ForecastTableProps {
   weatherData: Array<{
@@ -62,8 +61,8 @@ const formatTemperature = (temp: number, unit: string, isHigh: boolean) => {
   );
 };
 
-const ForecastTable: React.FC<ForecastTableProps> = memo(({ weatherData }) => {
-  const renderForecastPeriods = useCallback((data: ForecastResponse) => {
+const ForecastTable: React.FC<ForecastTableProps> = ({ weatherData }) => {
+  const renderForecastPeriods = (data: ForecastResponse) => {
     const periods = data.properties.periods.slice(0, 14); // Show next 7 days (14 periods)
     
     return periods.map((period) => {
@@ -88,7 +87,7 @@ const ForecastTable: React.FC<ForecastTableProps> = memo(({ weatherData }) => {
         precipitation: period.probabilityOfPrecipitation?.value || null,
       };
     });
-  }, []);
+  };
 
   return (
     <div>
@@ -137,8 +136,6 @@ const ForecastTable: React.FC<ForecastTableProps> = memo(({ weatherData }) => {
       
     </div>
   );
-});
-
-ForecastTable.displayName = 'ForecastTable';
+};
 
 export default ForecastTable;

--- a/src/components/HourlyChart.tsx
+++ b/src/components/HourlyChart.tsx
@@ -1,7 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { HourlyForecastResponse } from '../weatherData/weatherApi';
-import { memo } from 'react';
 
 interface HourlyChartProps {
   weatherData: Array<{
@@ -11,11 +10,11 @@ interface HourlyChartProps {
   }>;
 }
 
-const HourlyChart: React.FC<HourlyChartProps> = memo(({ weatherData }) => {
+const HourlyChart: React.FC<HourlyChartProps> = ({ weatherData }) => {
   const [startTimeOffset, setStartTimeOffset] = useState<number>(0);
 
   // Get start time options (every 6 hours for the next 24 hours)  
-  const getStartTimeOptions = useCallback(() => {
+  const getStartTimeOptions = () => {
     const options = [];
     const now = new Date();
     
@@ -51,10 +50,10 @@ const HourlyChart: React.FC<HourlyChartProps> = memo(({ weatherData }) => {
       });
     }
     return options;
-  }, []);
+  };
 
   // Process the data for each area's chart (take 48 hours starting from selected offset)
-  const processChartData = useCallback((data: HourlyForecastResponse) => {
+  const processChartData = (data: HourlyForecastResponse) => {
     return data.properties.periods.slice(startTimeOffset, startTimeOffset + 48).map((period) => {
       const date = new Date(period.startTime);
       return {
@@ -72,9 +71,9 @@ const HourlyChart: React.FC<HourlyChartProps> = memo(({ weatherData }) => {
         precipitation: period.probabilityOfPrecipitation?.value ?? null,
       };
     });
-  }, [startTimeOffset]);
+  };
 
-  const formatTooltip = useCallback((value: unknown, name: string, props: any) => {
+  const formatTooltip = (value: unknown, name: string, props: any) => {
     const numValue = value as number | null;
     if (name === 'temperature') {
       return [`${numValue}°${props.payload.temperatureUnit}`, 'Temperature'];
@@ -86,20 +85,20 @@ const HourlyChart: React.FC<HourlyChartProps> = memo(({ weatherData }) => {
       return [`${numValue}%`, 'Precipitation'];
     }
     return [numValue, name];
-  }, []);
+  };
 
-  const formatLabel = useCallback((label: string, payload?: any[]) => {
+  const formatLabel = (label: string, payload?: any[]) => {
     if (payload && payload.length > 0) {
       return payload[0].payload.fullTime;
     }
     return label;
-  }, []);
+  };
 
   const startTimeOptions = getStartTimeOptions();
 
-  const handleStartTimeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleStartTimeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setStartTimeOffset(Number(e.target.value));
-  }, []);
+  };
 
   const renderChart = (areaData: { areaKey: string; areaName: string; data: HourlyForecastResponse }, index: number) => {
     const chartData = processChartData(areaData.data);
@@ -245,8 +244,6 @@ const HourlyChart: React.FC<HourlyChartProps> = memo(({ weatherData }) => {
       {weatherData.map((areaData, index) => renderChart(areaData, index))}
     </div>
   );
-});
-
-HourlyChart.displayName = 'HourlyChart';
+};
 
 export default HourlyChart;


### PR DESCRIPTION
This was at least partially the cause of #25 -- it doesn't seem to have completely fixed the problem of stale chart data, but it prompted an immediate refresh, which I'm taking as a good sign